### PR TITLE
Sample Configを修正

### DIFF
--- a/src/config-sample.js
+++ b/src/config-sample.js
@@ -51,17 +51,17 @@ const layerConfigurations = [
     ],
   },
 ];
+
+const format = { // 元画像の大きさに合わせて修正
+  width: 512,
+  height: 512,
+  smoothing: false, // ピクセルアートの場合に利用する <参考>https://developer.mozilla.org/ja/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled
+};
 ///// ↑修正必要箇所↑ /////
 
 const shuffleLayerConfigurations = false;
 
 const debugLogs = false;
-
-const format = {
-  width: 512,
-  height: 512,
-  smoothing: false,
-};
 
 const gif = {
   export: false,


### PR DESCRIPTION
生成元の画像に合わせてformatも修正しなければ、画質が荒くなることが判明しました。
そのため、formatも修正必要箇所に追加しました。

手順書にもformatを修正する旨追加しました。
<img width="870" alt="スクリーンショット 2022-08-25 13 48 48" src="https://user-images.githubusercontent.com/64312219/186577374-a3262c94-4fca-4320-95cc-33017fbbb8d7.png">
https://docs.google.com/spreadsheets/d/1R0OwMB9rNhVirBd5mTeLlZf36f3FyEB4ekkJjJXAAEE/edit#gid=924790368

また手戻りが発生しないように、hashlipsで生成する場合は数枚をサンプルとして確認してもらう旨手順に追加しました。
<img width="714" alt="スクリーンショット 2022-08-25 13 44 27" src="https://user-images.githubusercontent.com/64312219/186577281-f2695d98-d266-47e3-8d96-adaedabbc1cd.png">

