### PR TITLE
エラーハンドリング追加

### DIFF
--- a/src/config-sample.js
+++ b/src/config-sample.js
@@ -32,7 +32,7 @@ const layerConfigurations = [
           Eyeball: [
             {
               targetTraits: ["Red"], // 対象となるtrait名
-              paierLyaerName: "Iris", // 制限したいtraitがあるlayer名
+              pairLayerName: "Iris", // 制限したいtraitがあるlayer名
               pairTraits: ["Small", "Medium"], // ペアとなるtrait名
             },
           ],
@@ -40,7 +40,7 @@ const layerConfigurations = [
             {
               // 以下のように除外したいtraitも選ぶことができる
               targetTraits: ["Yellow", "Red"], // 対象となるtrait名
-              paierLyaerName: "Top lid", // 制限したいtraitがあるlayer名
+              pairLayerName: "Top lid", // 制限したいtraitがあるlayer名
               excludedTraits: ["Middle"], // 除外したいtrait名
             },
           ],

--- a/src/main.js
+++ b/src/main.js
@@ -313,6 +313,7 @@ const createDna = (_layers) => {
     }
 
     if (elements.length === 0) {
+      console.log("pairLayerMap", pairLayerMap);
       throw new Error(`Can't select trait for ${layer.name}`);
     }
 
@@ -344,6 +345,7 @@ const createDna = (_layers) => {
                   (existValue.pairTraits.length !== pairLayer.pairTraits.length ||
                     existValue.pairTraits.some((trait) => pairLayer.pairTraits.indexOf(trait) === -1))
                 ) {
+                  console.log("pairLayerMap", pairLayerMap);
                   throw new Error(
                     `The pairTrait for ${pairLayer.pairLayerName} is duplicated. layer: ${layer.name}, trait: ${elements[i].name}`
                   );

--- a/src/main.js
+++ b/src/main.js
@@ -118,6 +118,7 @@ const pairLayerValidation = (_checkLayer, _pairLayers, _layersDir) => {
     // excludedTraits存在確認
     checkTraits(pairLayer, "excludedTraits", `${_layersDir}/${pairLayer.pairLayerName}`);
   }
+  return true;
 };
 
 const checkTraits = (_pairLayer, _checkTraits, _layerPath) => {

--- a/src/main.js
+++ b/src/main.js
@@ -303,9 +303,9 @@ const createDna = (_layers) => {
               (pairLayer) => pairLayer.targetTraits.includes(elements[i].name) // pairLayers指定のあるtraitsかどうか確認
             )
             .forEach((pairLayer) => {
-              if (pairLayerMap.has(pairLayer.paierLyaerName)) {
+              if (pairLayerMap.has(pairLayer.pairLayerName)) {
                 // すでにmap内にpairLayerが存在する場合は、pairTraitsとexcludedTraitsを追加
-                const existValue = pairLayerMap.get(pairLayer.paierLyaerName);
+                const existValue = pairLayerMap.get(pairLayer.pairLayerName);
 
                 // 同じLayerに対して複数のpairTraitsを設定すると矛盾が生じるのでエラーを返す
                 if (
@@ -315,17 +315,17 @@ const createDna = (_layers) => {
                     existValue.pairTraits.some((trait) => pairLayer.pairTraits.indexOf(trait) === -1))
                 ) {
                   throw new Error(
-                    `The pairTrait for ${pairLayer.paierLyaerName} is duplicated. layer: ${layer.name}, trait: ${elements[i].name}`
+                    `The pairTrait for ${pairLayer.pairLayerName} is duplicated. layer: ${layer.name}, trait: ${elements[i].name}`
                   );
                 }
 
-                pairLayerMap.set(pairLayer.paierLyaerName, {
+                pairLayerMap.set(pairLayer.pairLayerName, {
                   pairTraits: [...existValue.pairTraits, ...(pairLayer.pairTraits || [])],
                   excludedTraits: [...existValue.excludedTraits, ...(pairLayer.excludedTraits || [])],
                 });
               } else {
                 // map内にpairLayerが存在しない場合は、pairTraitsとexcludedTraitsを初期化
-                pairLayerMap.set(pairLayer.paierLyaerName, {
+                pairLayerMap.set(pairLayer.pairLayerName, {
                   pairTraits: pairLayer.pairTraits || [],
                   excludedTraits: pairLayer.excludedTraits || [],
                 });


### PR DESCRIPTION
存在していないtraitを指定している場合、エラーが出ることを確認

```
junichiro@hashlips_art_engine % node index.js coinfra-samurai                                                                                                                         ?[error]
(node:89485) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
/Users/junichiro/shpn/hashlips_art_engine/src/main.js:130
      throw new Error(`${trait} doesn't exist: ${_layerPath}/${trait}`);
            ^

Error: hogehoge doesn't exist: /Users/junichiro/shpn/hashlips_art_engine/layers-coinfra-samurai/Eyes-Eyewear-Back/hogehoge
    at checkTraits (/Users/junichiro/shpn/hashlips_art_engine/src/main.js:130:13)
    at pairLayerValidation (/Users/junichiro/shpn/hashlips_art_engine/src/main.js:113:5)
    at /Users/junichiro/shpn/hashlips_art_engine/src/main.js:102:9
    at Array.map (<anonymous>)
    at /Users/junichiro/shpn/hashlips_art_engine/src/main.js:93:26
    at Array.map (<anonymous>)
    at layerOptionsSetup (/Users/junichiro/shpn/hashlips_art_engine/src/main.js:91:37)
    at startCreating (/Users/junichiro/shpn/hashlips_art_engine/src/main.js:432:26)
    at /Users/junichiro/shpn/hashlips_art_engine/index.js:6:3
    at Object.<anonymous> (/Users/junichiro/shpn/hashlips_art_engine/index.js:7:3)

```